### PR TITLE
Bug fixes on Task4

### DIFF
--- a/src/components/task4/IntervalsScheduler/IntervalsScheduler.js
+++ b/src/components/task4/IntervalsScheduler/IntervalsScheduler.js
@@ -78,13 +78,13 @@ export default class IntervalsScheduler extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener("mousedown", this.handleClickOutside.bind(this));
+    document.addEventListener("mousedown", this.handleClickOutside);
   }
 
   componentWillUnmount() {
     document.removeEventListener(
       "mousedown",
-      this.handleClickOutside.bind(this)
+      this.handleClickOutside
     );
   }
 
@@ -103,7 +103,7 @@ export default class IntervalsScheduler extends React.Component {
     });
   }
 
-  handleClickOutside(event) {
+  handleClickOutside = (event) => {
     const { intervalPopupRef } = this;
     if (!intervalPopupRef.current.contains(event.target)) {
       this.setState({ popoverVisible: false });
@@ -297,7 +297,7 @@ export default class IntervalsScheduler extends React.Component {
         hour < interval.startDatetime.hour) ||
       day > this.state.stopMeasurement.day ||
       (day === this.state.stopMeasurement.day &&
-        hour > this.state.stopMeasurement.hour)
+        hour >= this.state.stopMeasurement.hour)
     ) {
       return false;
     }


### PR DESCRIPTION
-app was crashing after getting out of task4 and clicking anywhere; task4 was having a small bug that when the interval was ending right when the measurement stops, the red bullet was not shown